### PR TITLE
Description of -t and --title is wrong. Add description for help and …

### DIFF
--- a/man/lxterminal.xml
+++ b/man/lxterminal.xml
@@ -55,23 +55,36 @@ Except in the <option>--command=</option> form, this must be the last option on 
 	<listitem>	  <para>Set the terminal's size in characters and lines.</para>
 	</listitem>
       </varlistentry>
+      <varlistentry>	<term>	  <option>-h</option>
+	  <option>--help</option>
+	</term>fixes
+	<listitem>	  <para>Prints a short help message, and exit.</para>
+	</listitem>
+      </varlistentry>
       <varlistentry>	<term>	  <option>-l</option>
 	  <option>--loginshell</option>
 	</term>
 	<listitem>	  <para>Executes login shell.</para>
 	</listitem>
       </varlistentry>
-      <varlistentry>	<term>	  <option>-t <replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
-	  <option>--title=<replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
+      <varlistentry>	<term>	  <option>-T <replaceable>NAME</replaceable></option>
+	  <option>-t <replaceable>NAME</replaceable></option>
+	  <option>--title=<replaceable>NAME</replaceable></option>
 	  <option>--tabs=<replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
 	</term>
-	<listitem>	  <para>Set the terminal's title. Use comma for multiple tabs.</para>
+	<listitem>	  <para>Set the terminal's title. Comma separated multiple titles create multiple tabs only with the <option>--tabs=</option> form.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>        <term>          <option>--working-directory=<replaceable>DIRECTORY</replaceable></option>
         </term>
         <listitem>          <para>Set the terminal's working directory.</para>
         </listitem>
+      </varlistentry>
+      <varlistentry>	<term>	  <option>-v</option>
+	  <option>--version</option>
+	</term>
+	<listitem>	  <para>Prints version information, and exit.</para>
+	</listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/lxterminal.xml
+++ b/man/lxterminal.xml
@@ -57,7 +57,7 @@ Except in the <option>--command=</option> form, this must be the last option on 
       </varlistentry>
       <varlistentry>	<term>	  <option>-h</option>
 	  <option>--help</option>
-	</term>fixes
+	</term>
 	<listitem>	  <para>Prints a short help message, and exit.</para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
For lxterminal 0.4.0:
1. Fixes descriptions of -t and --title in the manual page. Compare it with lxterminal -h.
2. Add entries for the help and version options.