### PR TITLE
At least two tabs must be requested for tabs creation

### DIFF
--- a/man/lxterminal.xml
+++ b/man/lxterminal.xml
@@ -70,7 +70,7 @@ Except in the <option>--command=</option> form, this must be the last option on 
       <varlistentry>	<term>	  <option>-T <replaceable>NAME</replaceable></option>
 	  <option>-t <replaceable>NAME</replaceable></option>
 	  <option>--title=<replaceable>NAME</replaceable></option>
-	  <option>--tabs=<replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
+	  <option>--tabs=<replaceable>NAME,NAME[,NAME[...]]</replaceable></option>
 	</term>
 	<listitem>	  <para>Set the terminal's title. Comma separated multiple titles create multiple tabs only with the <option>--tabs=</option> form.</para>
 	</listitem>


### PR DESCRIPTION
When I try `lxterminal --no-remote --tabs='1,'`, no tabs are created. By a bit more testing I made, I am convinced  this patch better reflects lxterminal behavior. At least two tabs must be requested in order for tabs to get created.
Turn out the above is not fully correct. `lxterminal --no-remote --tabs='1,'` does create a tab. a hidden tab. The hidden tab will be revealed when another tab will be requested. I will try to take back my pull request. Though I do think that what happens in this case should be documented. Only that my pull request does not document it correctly.